### PR TITLE
Modifications to recent Putrid Alcove changes

### DIFF
--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -5962,7 +5962,11 @@ Asset id: 3418828153
   > Putrid Alcove/Door to Dark Forgotten Bridge
       Trivial
   > Putrid Alcove/Pickup (Power Bomb)
-      Morph Ball and Power Bomb and Dark World Damage ≥ 75
+      All of the following:
+          Morph Ball and Power Bomb
+          Any of the following:
+              Space Jump Boots and Dark World Damage ≥ 70
+              Morph Ball Bomb and Dark World Damage ≥ 120
 
 > Door to Dark Forgotten Bridge; Heals? False
   > Dark Forgotten Bridge/Door to Putrid Alcove
@@ -5970,13 +5974,25 @@ Asset id: 3418828153
   > Putrid Alcove/Door to Poisoned Bog
       Trivial
   > Putrid Alcove/Pickup (Power Bomb)
-      Morph Ball and Power Bomb and Dark World Damage ≥ 75
+      All of the following:
+          Morph Ball and Power Bomb
+          Any of the following:
+              Space Jump Boots and Dark World Damage ≥ 70
+              Morph Ball Bomb and Dark World Damage ≥ 120
 
 > Pickup (Power Bomb); Heals? False
   > Putrid Alcove/Door to Poisoned Bog
-      Morph Ball and Power Bomb and Dark World Damage ≥ 100
+      All of the following:
+          Morph Ball and Power Bomb
+          Any of the following:
+              Space Jump Boots and Dark World Damage ≥ 40
+              Morph Ball Bomb and Dark World Damage ≥ 60
   > Putrid Alcove/Door to Dark Forgotten Bridge
-      Morph Ball and Power Bomb and Dark World Damage ≥ 100
+      All of the following:
+          Morph Ball and Power Bomb
+          Any of the following:
+              Space Jump Boots and Dark World Damage ≥ 40
+              Morph Ball Bomb and Dark World Damage ≥ 60
 
 ----------------
 Brooding Ground


### PR DESCRIPTION
Previous commit had a single damage requirement for either direction. Added a separation of logic for having just SJ or just Bombs, each with respective damage requirements getting the item and leaving the room.